### PR TITLE
Proposal: Comments and IDs

### DIFF
--- a/Brauser.Common/Recipe/AdditionalFermentationIngredient.cs
+++ b/Brauser.Common/Recipe/AdditionalFermentationIngredient.cs
@@ -2,6 +2,7 @@ namespace Brauser.Common.Recipe;
 
 public class AdditionalFermentationIngredient
 {
+    public Guid Id { get; set; }
     public int? Order { get; set; }
     public string? Name { get; set; }
     public int? Quantity { get; set; }

--- a/Brauser.Common/Recipe/DryHop.cs
+++ b/Brauser.Common/Recipe/DryHop.cs
@@ -2,6 +2,7 @@ namespace Brauser.Common.Recipe;
 
 public class DryHop
 {
+    public Guid Id { get; set; }
     public string? Variety { get; set; }
     public string? Quantity { get; set; }
 }

--- a/Brauser.Common/Recipe/Hop.cs
+++ b/Brauser.Common/Recipe/Hop.cs
@@ -2,6 +2,7 @@ namespace Brauser.Common.Recipe;
 
 public record Hop
 {
+    public Guid Id { get; set; }
     public int? Order { get; set; }
     public string? Variety { get; set; }
     public double? Quantity { get; set; }

--- a/Brauser.Common/Recipe/Infusion.cs
+++ b/Brauser.Common/Recipe/Infusion.cs
@@ -2,6 +2,7 @@ namespace Brauser.Common.Recipe;
 
 public record Infusion
 {
+    public Guid Id { get; set; }
     public int Order { get; set; }
     public double RestTemperature { get; set; }
     public TimeSpan RestTime { get; set; }

--- a/Brauser.Common/Recipe/Malt.cs
+++ b/Brauser.Common/Recipe/Malt.cs
@@ -2,6 +2,7 @@ namespace Brauser.Common.Recipe;
 
 public record Malt
 {
+    public Guid Id { get; set; }
     public int? Order { get; set; }
     public string? Name { get; set; }
     public double? Quantity { get; set; }

--- a/Brauser.Common/Recipe/Recipe.cs
+++ b/Brauser.Common/Recipe/Recipe.cs
@@ -2,32 +2,60 @@ namespace Brauser.Common.Recipe;
 
 public record Recipe
 {
+    public Guid Id { get; set; }
     public string? Name { get; set; }
     public DateTimeOffset? Date { get; set; }
     public string? Type { get; set; }
 
-    public int? BatchSize { get; set; } // Ausschlagwürze
-    public int? BrewhouseYield { get; set; } // Sudhausausbeute
-    public double? OriginalGravity { get; set; } // Stammwürze
-    public int? Bitterness { get; set; } // Bittere
+    /// <summary>
+    /// Ausschlagwürze
+    /// </summary>
+    public int? BatchSize { get; set; }
+    /// <summary>
+    /// Sudhausausbeute
+    /// </summary>
+    public int? BrewhouseYield { get; set; }
+    /// <summary>
+    /// Stammwürze
+    /// </summary>
+    public double? OriginalGravity { get; set; }
+    /// <summary>
+    /// Bittere
+    /// </summary>
+    public int? Bitterness { get; set; }
 
     public string? Color { get; set; }
     public double? Alcohol { get; set; }
     public string? ShortDescription { get; set; }
 
-    public int? MashWater { get; set; } // Hauptguss
+    /// <summary>
+    /// Hauptguss
+    /// </summary>
+    public int? MashWater { get; set; }
 
     public List<Malt>? Malts { get; set; }
 
-    public double? MashingTemperature { get; set; } // InfusionEinmaischTemperatur
-
+    /// <summary>
+    /// EinmaischTemperatur
+    /// </summary>
+    public double? MashingTemperature { get; set; }
+    
     public List<Infusion>? Infusions { get; set; }
 
-    public double? MashoutTemperature { get; set; } // Abmaischtemperatur
+    /// <summary>
+    /// Abmaischtemperatur
+    /// </summary>
+    public double? MashoutTemperature { get; set; }
 
-    public int? SpargeWater { get; set; } // Nachguss
+    /// <summary>
+    /// Nachguss
+    /// </summary>
+    public int? SpargeWater { get; set; }
 
-    public TimeSpan? WortBoilingTime { get; set; } // Kochzeitwürze
+    /// <summary>
+    /// Kochzeit Würze
+    /// </summary>
+    public TimeSpan? WortBoilingTime { get; set; }
 
     public string? HopVWH_1_Variety { get; set; } // Sorte
     public double? HopVWH_1_Quantity { get; set; } // Menge
@@ -35,11 +63,22 @@ public record Recipe
 
     public List<Hop>? Hops { get; set; }
     
-    public List<DryHop>? DryHops { get; set; } // StopfHopfen
+    /// <summary>
+    /// Hopfen für Hopfenstopfen/Kalthopfung
+    /// </summary>
+    public List<DryHop>? DryHops { get; set; }
     public List<AdditionalFermentationIngredient>? AdditionalFermentationIngredients { get; set; }
     public string? Yeast { get; set; }
-    public double? FermentationTemperature { get; set; } // Gaertemperatur
-    public string? FinalDegreeOfFermentation { get; set; } // Endvergaerungsgrad
+    
+    /// <summary>
+    /// Gaertemperatur
+    /// </summary>
+    public double? FermentationTemperature { get; set; }
+    
+    /// <summary>
+    /// Endvergaerungsgrad
+    /// </summary>
+    public string? FinalDegreeOfFermentation { get; set; } 
     public string? Carbonation { get; set; }
     public string? AuthorNotes { get; set; }
 }


### PR DESCRIPTION
As discussed in one of the issues in the Editor project, it would be of great help for the frontend-backend-communication if all the entities would have an ID. So this is a proposal to simply add a `public Guid Id { get; set; }` to the entities.

I also moved the german translations in the comments to summary-comments. This will make them available in the projects using this package. We can remove them later if we no longer need them, but I think for the start this will be helpful.