### PR TITLE
feat: Make fields on `Recipe` mandatory

### DIFF
--- a/Brauser.Common/Recipe/Recipe.cs
+++ b/Brauser.Common/Recipe/Recipe.cs
@@ -4,9 +4,9 @@ public record Recipe
 {
     public Guid Id { get; set; }
 
-    public GeneralInformation? GeneralInformation { get; set; }
+    public GeneralInformation GeneralInformation { get; set; }
 
-    public BrewingProcess? BrewingProcess { get; set; }
+    public BrewingProcess BrewingProcess { get; set; }
 
-    public FermentationAndMaturing? FermentationAndMaturing { get; set; }
+    public FermentationAndMaturing FermentationAndMaturing { get; set; }
 }

--- a/Brauser.Common/Recipe/Recipe.cs
+++ b/Brauser.Common/Recipe/Recipe.cs
@@ -2,6 +2,13 @@ namespace Brauser.Common.Recipe;
 
 public record Recipe
 {
+    public Recipe()
+    {
+        GeneralInformation = new GeneralInformation();
+        BrewingProcess = new BrewingProcess();
+        FermentationAndMaturing = new FermentationAndMaturing();
+    }
+    
     public Guid Id { get; set; }
 
     public GeneralInformation GeneralInformation { get; set; }


### PR DESCRIPTION
I think it would be good to make all fields on the `Recipe` mandatory.
Of course, this comes with a few implications. But for me, every `Recipe` *must* contain general information and also *must* contain some information about the brewing process, etc. 
We could simplify this by adding something like `GeneralInformation = new GeneralInformation();` etc. to the constructor. What do you think, @tdankert?

Keeping it optional will always lead to a lot of `if (recipe.GeneralInformation is null)` in the code.