### PR TITLE
fix(versioning): Removed leading 0 in month and day

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -26,7 +26,10 @@ jobs:
       
     - name: Set version
       run: |
-        version=$(date +'%Y.%m.%d').$GITHUB_RUN_NUMBER
+        year=$(date +'%Y')
+        month=$(date +'%-m')
+        day=$(date +'%-d')
+        version="$year.$month.$day-$GITHUB_RUN_NUMBER"
         echo "VERSION=$version" >> $GITHUB_ENV
 
     - name: pack nuget


### PR DESCRIPTION
Nuget pack removed the leading 0 in day (minor) an month (patch). This lead to an error when searching the package for publishing.
This removes the leading 0 while constructing the version string.